### PR TITLE
Escape curly braces in deprecation reason

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Escape curly braces in deprecations' reason for MDX cross-compatibility
+
 ## 0.8.2 - 2023-02-12
 
 ### Fixed

--- a/packages/docusaurus-graphql-plugin/src/__tests__/__snapshots__/converters.ts.snap
+++ b/packages/docusaurus-graphql-plugin/src/__tests__/__snapshots__/converters.ts.snap
@@ -25,7 +25,7 @@ Represents a user's role.
 <tr>
 <td>Anonymous</td>
 <td>
-<blockquote>Deprecated: Anonymous will be removed with the next major release</blockquote>
+<blockquote>Deprecated: &#123; Anonymous &#125; will be removed with the next major release</blockquote>
 <p>Unknown user</p>
 </td>
 </tr>
@@ -173,7 +173,7 @@ exports[`converters mutations should convert mutations to markdown 1`] = `
 
 **Type:** [User!](/objects#user)
 
-> Deprecated: createAdmin will be removed with the next major release
+> Deprecated: &#123; createAdmin &#125; will be removed with the next major release
 
 Mutation to create a new admin.
 
@@ -280,7 +280,7 @@ exports[`converters queries should convert queries to markdown 1`] = `
 
 **Type:** [User!](/objects#user)
 
-> Deprecated: admin will be removed with the next major release
+> Deprecated: admin will be removed with the next major release, use &#123; user &#125; instead
 
 Query to get an admin.
 

--- a/packages/docusaurus-graphql-plugin/src/__tests__/converters.ts
+++ b/packages/docusaurus-graphql-plugin/src/__tests__/converters.ts
@@ -21,7 +21,7 @@ describe("converters", () => {
           """
           admin("The admin's id." id: ID!): User!
             @deprecated(
-              reason: "admin will be removed with the next major release"
+              reason: "admin will be removed with the next major release, use { user } instead"
             )
         }
         type User {
@@ -62,7 +62,7 @@ describe("converters", () => {
           """
           createAdmin("The new admin's name" name: String!): User!
             @deprecated(
-              reason: "createAdmin will be removed with the next major release"
+              reason: "{ createAdmin } will be removed with the next major release"
             )
         }
         type User {
@@ -198,7 +198,7 @@ describe("converters", () => {
           "Unknown user"
           Anonymous
             @deprecated(
-              reason: "Anonymous will be removed with the next major release"
+              reason: "{ Anonymous } will be removed with the next major release"
             )
         }
       `);

--- a/packages/docusaurus-graphql-plugin/src/converters/convertEnumToMarkdown.ts
+++ b/packages/docusaurus-graphql-plugin/src/converters/convertEnumToMarkdown.ts
@@ -1,6 +1,6 @@
 import { GraphQLEnumType } from "graphql";
 import { MarkdownConverterOptions } from "../types";
-import { parseMarkdown } from "./parseMarkdown";
+import { escapeSpecialCharacters, parseMarkdown } from "./parseMarkdown";
 
 export function convertEnumToMarkdown(
   enm: GraphQLEnumType,
@@ -31,7 +31,9 @@ export function convertEnumToMarkdown(
 
     if (value.deprecationReason) {
       lines.push(
-        `<blockquote>Deprecated: ${value.deprecationReason}</blockquote>`,
+        `<blockquote>Deprecated: ${escapeSpecialCharacters(
+          value.deprecationReason
+        )}</blockquote>`,
         `\n`
       );
     }

--- a/packages/docusaurus-graphql-plugin/src/converters/convertMutationToMarkdown.ts
+++ b/packages/docusaurus-graphql-plugin/src/converters/convertMutationToMarkdown.ts
@@ -1,5 +1,6 @@
 import { GraphQLField } from "graphql";
 import { MarkdownConverterOptions } from "../types";
+import { escapeSpecialCharacters } from "./parseMarkdown";
 import { pushArguments } from "./pushArguments";
 
 export function convertMutationToMarkdown(
@@ -21,7 +22,10 @@ export function convertMutationToMarkdown(
   );
 
   if (mutation.deprecationReason) {
-    lines.push(`> Deprecated: ${mutation.deprecationReason}`, `\n\n`);
+    lines.push(
+      `> Deprecated: ${escapeSpecialCharacters(mutation.deprecationReason)}`,
+      `\n\n`
+    );
   }
 
   lines.push(mutation.description || "", `\n\n`);

--- a/packages/docusaurus-graphql-plugin/src/converters/convertQueryToMarkdown.ts
+++ b/packages/docusaurus-graphql-plugin/src/converters/convertQueryToMarkdown.ts
@@ -1,5 +1,6 @@
 import { GraphQLField } from "graphql";
 import { MarkdownConverterOptions } from "../types";
+import { escapeSpecialCharacters } from "./parseMarkdown";
 import { pushArguments } from "./pushArguments";
 
 export function convertQueryToMarkdown(
@@ -18,7 +19,10 @@ export function convertQueryToMarkdown(
   );
 
   if (query.deprecationReason) {
-    lines.push(`> Deprecated: ${query.deprecationReason}`, `\n\n`);
+    lines.push(
+      `> Deprecated: ${escapeSpecialCharacters(query.deprecationReason)}`,
+      `\n\n`
+    );
   }
 
   lines.push(query.description || "", `\n\n`);

--- a/packages/docusaurus-graphql-plugin/src/converters/parseMarkdown.ts
+++ b/packages/docusaurus-graphql-plugin/src/converters/parseMarkdown.ts
@@ -1,10 +1,14 @@
 import marked from "marked";
 
+export function escapeSpecialCharacters(str: string): string {
+  return str.replace(/\{/g, "&#123;").replace(/\}/g, "&#125;");
+}
+
 export function parseMarkdown(markdown: string): string {
   const walkTokens = (token: marked.Token) => {
     if (token.type === "text" || token.type === "codespan") {
       // make the Markdown compatible with MDX by escaping curly braces
-      token.text = token.text.replace(/\{/g, "&#123;").replace(/\}/g, "&#125;");
+      token.text = escapeSpecialCharacters(token.text);
     }
   };
   return marked

--- a/packages/docusaurus-graphql-plugin/src/converters/pushArguments.ts
+++ b/packages/docusaurus-graphql-plugin/src/converters/pushArguments.ts
@@ -1,6 +1,6 @@
 import { GraphQLArgument, GraphQLInputField } from "graphql";
 import { MarkdownConverterOptions } from "../types";
-import { parseMarkdown } from "./parseMarkdown";
+import { escapeSpecialCharacters, parseMarkdown } from "./parseMarkdown";
 
 export function pushArguments(
   lines: string[],
@@ -36,7 +36,9 @@ export function pushArguments(
 
     if (arg.deprecationReason) {
       lines.push(
-        `<blockquote>Deprecated: ${arg.deprecationReason}</blockquote>`,
+        `<blockquote>Deprecated: ${escapeSpecialCharacters(
+          arg.deprecationReason
+        )}</blockquote>`,
         `\n\n`
       );
     }

--- a/packages/docusaurus-graphql-plugin/src/converters/pushFields.ts
+++ b/packages/docusaurus-graphql-plugin/src/converters/pushFields.ts
@@ -1,7 +1,7 @@
 import { GraphQLField } from "graphql";
 import { MarkdownConverterOptions } from "../types";
 import { pushArguments } from "./pushArguments";
-import { parseMarkdown } from "./parseMarkdown";
+import { escapeSpecialCharacters, parseMarkdown } from "./parseMarkdown";
 
 export function pushFields(
   lines: string[],
@@ -37,7 +37,9 @@ export function pushFields(
 
     if (field.deprecationReason) {
       lines.push(
-        `<blockquote>Deprecated: ${field.deprecationReason}</blockquote>`,
+        `<blockquote>Deprecated: ${escapeSpecialCharacters(
+          field.deprecationReason
+        )}</blockquote>`,
         `\n\n`
       );
     }


### PR DESCRIPTION
This PR escapes curly braces in the deprecation reason and fixes #17 