### PR TITLE
Adds Relative Paths in Links Between Generated Pages and Sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,37 +113,18 @@ Can be a path, a glob or an URL used to load your GraphQL schema.
 
 **Defaults:** `/docs/api/`
 
-This option is used for two things:
+This option can be used to customize the output folder and thus the GraphQL docs' path.
 
-1. To generate reference links, such as the return type of a query being linked to its corresponding object.
-2. To generate the path where the files will be written to disk.
-
-So if you want the API docs to be served over `/docs/api-reference/` instead of `/docs/api/`, you can change this option to `/docs/api-reference/`. Note that you can also have more levels to the path, e.g `/docs/reference/api/`.
-
-**You must change this option if you are using the docs plugin's `routeBasePath`.**
-For example, if you opted for a docs only documentation, your configuration could look like this:
+For example if you want the API docs to be served over `/docs/api-reference/` instead of `/docs/api/`, you can change this option to `/docs/api-reference/`. Note that you can also have more levels to the path, e.g `/docs/reference/api/`.
 
 ```js
 module.exports = {
-  presets: [
-    [
-      "@docusaurus/preset-classic",
-      {
-        docs: {
-          // with the change below, docs are server over `/` instead of `/docs/`
-          routeBasePath: "/",
-        },
-      },
-    ],
-  ],
   plugins: [
     [
       "docusaurus-graphql-plugin",
       {
         schema: "schema.graphql",
-
-        // routeBasePath defaults to `/docs/api/` which will not work if docs are server over `/`
-        routeBasePath: "/api/",
+        routeBasePath: "/docs/api-reference/",
       },
     ],
   ],

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Add support for i18n by using relative links instead of absolute
+
+### Changed
+
+- Use relative links for references
+
 ## 0.8.3 - 2023-03-25
 
 ### Fixed

--- a/packages/docusaurus-graphql-plugin/package.json
+++ b/packages/docusaurus-graphql-plugin/package.json
@@ -33,15 +33,13 @@
     "@graphql-tools/url-loader": "^7.9.21",
     "fs-extra": "^9.1.0",
     "joi": "^17.4.0",
-    "marked": "^2.0.3",
-    "url-join": "^4.0.1"
+    "marked": "^2.0.3"
   },
   "devDependencies": {
     "@docusaurus/types": "^2.0.0-alpha.72",
     "@types/fs-extra": "^9.0.11",
     "@types/jest": "^26.0.22",
     "@types/marked": "^2.0.2",
-    "@types/url-join": "^4.0.0",
     "graphql": "^16.0.0",
     "jest": "^26.6.3",
     "ts-jest": "^26.5.5",

--- a/packages/docusaurus-graphql-plugin/src/__tests__/__snapshots__/converters.ts.snap
+++ b/packages/docusaurus-graphql-plugin/src/__tests__/__snapshots__/converters.ts.snap
@@ -48,7 +48,7 @@ Input to create a new user.
 <tr>
 <td>
 name<br />
-<a href=\\"/scalars#string\\"><code>String!</code></a>
+<a href=\\"scalars#string\\"><code>String!</code></a>
 </td>
 <td>
 <p>The new user&#39;s name.</p>
@@ -73,7 +73,7 @@ Properties that are common to the different kind of users.
 <tr>
 <td>
 name<br />
-<a href=\\"/scalars#string\\"><code>String!</code></a>
+<a href=\\"scalars#string\\"><code>String!</code></a>
 </td>
 <td>
 <p>The user&#39;s name.</p>
@@ -92,7 +92,7 @@ Properties that are common to the different kind of users.
 
 <p style={{ marginBottom: \\"0.4em\\" }}><strong>Implemented by</strong></p>
 
-- [Admin](/objects#admin)
+- [Admin](objects#admin)
 
 <p style={{ marginBottom: \\"0.4em\\" }}><strong>Fields</strong></p>
 
@@ -102,7 +102,7 @@ Properties that are common to the different kind of users.
 <tr>
 <td>
 name<br />
-<a href=\\"/scalars#string\\"><code>String!</code></a>
+<a href=\\"scalars#string\\"><code>String!</code></a>
 </td>
 <td>
 <p>The user&#39;s name.</p>
@@ -121,7 +121,7 @@ A special kind of user.
 
 <p style={{ marginBottom: \\"0.4em\\" }}><strong>Implements</strong></p>
 
-- [User](/interfaces#user)
+- [User](interfaces#user)
 
 <p style={{ marginBottom: \\"0.4em\\" }}><strong>Fields</strong></p>
 
@@ -131,7 +131,7 @@ A special kind of user.
 <tr>
 <td>
 power<br />
-<a href=\\"/scalars#string\\"><code>String!</code></a>
+<a href=\\"scalars#string\\"><code>String!</code></a>
 </td>
 <td>
 <p>The admin&#39;s special power.</p>
@@ -146,7 +146,7 @@ Properties that are common to the different kind of users.
 
 <p style={{ marginBottom: \\"0.4em\\" }}><strong>Implemented by</strong></p>
 
-- [Admin](/interfaces#admin)
+- [Admin](interfaces#admin)
 
 <p style={{ marginBottom: \\"0.4em\\" }}><strong>Fields</strong></p>
 
@@ -156,7 +156,7 @@ Properties that are common to the different kind of users.
 <tr>
 <td>
 name<br />
-<a href=\\"/scalars#string\\"><code>String!</code></a>
+<a href=\\"scalars#string\\"><code>String!</code></a>
 </td>
 <td>
 <p>The user&#39;s name.</p>
@@ -171,7 +171,7 @@ name<br />
 exports[`converters mutations should convert mutations to markdown 1`] = `
 "## createAdmin
 
-**Type:** [User!](/objects#user)
+**Type:** [User!](objects#user)
 
 > Deprecated: &#123; createAdmin &#125; will be removed with the next major release
 
@@ -185,7 +185,7 @@ Mutation to create a new admin.
 <tr>
 <td>
 name<br />
-<a href=\\"/scalars#string\\"><code>String!</code></a>
+<a href=\\"scalars#string\\"><code>String!</code></a>
 </td>
 <td>
 <p>The new admin&#39;s name</p>
@@ -196,7 +196,7 @@ name<br />
 
 ## createUser
 
-**Type:** [User!](/objects#user)
+**Type:** [User!](objects#user)
 
 Mutation to create a new user.
 
@@ -208,7 +208,7 @@ Mutation to create a new user.
 <tr>
 <td>
 name<br />
-<a href=\\"/scalars#string\\"><code>String!</code></a>
+<a href=\\"scalars#string\\"><code>String!</code></a>
 </td>
 <td>
 <p>The new user&#39;s name</p>
@@ -233,7 +233,7 @@ exports[`converters objects should convert objects to markdown 1`] = `
 <tr>
 <td>
 id<br />
-<a href=\\"/scalars#id\\"><code>ID!</code></a>
+<a href=\\"scalars#id\\"><code>ID!</code></a>
 </td>
 <td>
 <p>This field&#39;s description contains special characters that should be escaped, such as &#123; and &#125;.</p>
@@ -253,7 +253,7 @@ A user with special rights.
 
 <p style={{ marginBottom: \\"0.4em\\" }}><strong>Implements</strong></p>
 
-- [User](/interfaces#user)
+- [User](interfaces#user)
 
 <p style={{ marginBottom: \\"0.4em\\" }}><strong>Fields</strong></p>
 
@@ -263,7 +263,7 @@ A user with special rights.
 <tr>
 <td>
 name<br />
-<a href=\\"/scalars#string\\"><code>String!</code></a>
+<a href=\\"scalars#string\\"><code>String!</code></a>
 </td>
 <td>
 <p>The admin&#39;s name.</p>
@@ -278,7 +278,7 @@ name<br />
 exports[`converters queries should convert queries to markdown 1`] = `
 "## admin
 
-**Type:** [User!](/objects#user)
+**Type:** [User!](objects#user)
 
 > Deprecated: admin will be removed with the next major release, use &#123; user &#125; instead
 
@@ -292,7 +292,7 @@ Query to get an admin.
 <tr>
 <td>
 id<br />
-<a href=\\"/scalars#id\\"><code>ID!</code></a>
+<a href=\\"scalars#id\\"><code>ID!</code></a>
 </td>
 <td>
 <p>The admin&#39;s id.</p>
@@ -303,7 +303,7 @@ id<br />
 
 ## user
 
-**Type:** [User!](/objects#user)
+**Type:** [User!](objects#user)
 
 Query to get a user.
 
@@ -315,7 +315,7 @@ Query to get a user.
 <tr>
 <td>
 id<br />
-<a href=\\"/scalars#id\\"><code>ID!</code></a>
+<a href=\\"scalars#id\\"><code>ID!</code></a>
 </td>
 <td>
 <p>The user&#39;s id.</p>
@@ -330,7 +330,7 @@ id<br />
 exports[`converters queries should support query referencing Query 1`] = `
 "## relay
 
-**Type:** [Query!](/queries#query)
+**Type:** [Query!](queries#query)
 
 Hack to workaround https://github.com/facebook/relay/issues/112 re-exposing the root query object.
 
@@ -360,8 +360,8 @@ Combination of the possible humanoids.
 
 <p style={{ marginBottom: \\"0.4em\\" }}><strong>Possible types</strong></p>
 
-- [User](/objects#user)
-- [Droid](/objects#droid)
+- [User](objects#user)
+- [Droid](objects#droid)
 
 "
 `;

--- a/packages/docusaurus-graphql-plugin/src/getRelativeTypeUrl.ts
+++ b/packages/docusaurus-graphql-plugin/src/getRelativeTypeUrl.ts
@@ -36,5 +36,5 @@ export function getRelativeTypeUrl(type: GraphQLType): string | undefined {
     return undefined;
   }
 
-  return `/${converter.id}#${sluggify(baseType.name)}`;
+  return `${converter.id}#${sluggify(baseType.name)}`;
 }

--- a/packages/docusaurus-graphql-plugin/src/index.ts
+++ b/packages/docusaurus-graphql-plugin/src/index.ts
@@ -24,6 +24,7 @@ interface PluginOptions {
     label: string;
     position: number;
   };
+  useRelativePaths: boolean;
 }
 
 const OptionsSchema = Joi.object<PluginOptions>({
@@ -34,6 +35,7 @@ const OptionsSchema = Joi.object<PluginOptions>({
     label: Joi.string(),
     position: Joi.number(),
   }),
+  useRelativePaths: Joi.boolean(),
 });
 
 export function validateOptions({
@@ -94,7 +96,7 @@ export default function plugin(
               getTypePath: (type: GraphQLType) => {
                 const relativeTypeUrl = getRelativeTypeUrl(type);
                 return relativeTypeUrl
-                  ? joinURL(baseUrl, relativeTypeUrl)
+                  ? joinURL(options.useRelativePaths ? '' : baseUrl, relativeTypeUrl)
                   : undefined;
               },
             });

--- a/packages/docusaurus-graphql-plugin/src/index.ts
+++ b/packages/docusaurus-graphql-plugin/src/index.ts
@@ -4,7 +4,6 @@ import {
   LoadContext,
   Plugin,
   OptionValidationContext,
-  ValidationResult,
 } from "@docusaurus/types";
 import { GraphQLType } from "graphql";
 import Joi from "joi";
@@ -41,7 +40,7 @@ const OptionsSchema = Joi.object<PluginOptions>({
 export function validateOptions({
   options,
   validate,
-}: OptionValidationContext<PluginOptions>): ValidationResult<PluginOptions> {
+}: OptionValidationContext<PluginOptions, PluginOptions>): PluginOptions {
   return validate(OptionsSchema, options);
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2291,11 +2291,6 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
 
-"@types/url-join@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@types/url-join/-/url-join-4.0.0.tgz#72eff71648a429c7d4acf94e03780e06671369bd"
-  integrity sha512-awrJu8yML4E/xTwr2EMatC+HBnHGoDxc2+ImA9QyeUELI1S7dOCIZcyjki1rkwoA8P2D2NVgLAJLjnclkdLtAw==
-
 "@types/webpack-sources@*":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@types/webpack-sources/-/webpack-sources-2.1.0.tgz#8882b0bd62d1e0ce62f183d0d01b72e6e82e8c10"
@@ -10763,11 +10758,6 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
-
-url-join@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/url-join/-/url-join-4.0.1.tgz#b642e21a2646808ffa178c4c5fda39844e12cde7"
-  integrity sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==
 
 url-loader@^4.1.1:
   version "4.1.1"


### PR DESCRIPTION
Allows usage of plugin in combination with Docusaurus' internationalization feature by introducing relative links to the "base URL" controlled by a plugin option (in case the absolute path behavior is required by other scenarios, this could be left as is)

As the i18n enablement of docusaurus itself, this change does not add support to keep the translated markdown files in sync or manage the translation process.

Resolve #19 